### PR TITLE
Remove duplicate local function definitions

### DIFF
--- a/damper.m
+++ b/damper.m
@@ -2085,13 +2085,6 @@ function dz = mck_rhs(tt,z,n,Ns,nd,hyd,geom,therm,num,cfg,Ap,Ao,k_sd,M,C,K,agf,r
 
     dz = [ v; dv; dp1; dp2; dQ; dT_o; dT_s ];
 end
-
-function Jp = local_JPattern(nn)
-    Ns   = nn - 1;
-    Ntot = 2*nn + 2*Ns + Ns + 2;
-    Jp   = sparse(ones(Ntot, Ntot));
-end
-
 function [drift, F_story, dP_orf_t, T_oil, T_steel, mu_t, E_cum, ...
           cav_frac_t, dP_q50, dP_q95, Q_abs_med, Q_abs_p95, ...
           cav_margin_t, cav_margin_min] = ...
@@ -2630,14 +2623,6 @@ end
 
 %% ===================== EKSİK/YARDIMCI FONKSİYONLAR =====================
 
-function val = getfield_default(S, name, defaultVal)
-% S alanı yoksa default döndürür
-    if ~isstruct(S) || ~isfield(S,name) || isempty(S.(name))
-        val = defaultVal;
-    else
-        val = S.(name);
-    end
-end
 
 function [tPSA, agPSA] = psa_grid(t, ag, down_dt)
 % PSA için opsiyonel yeniden örnekleme (yalnız downsample; upsample etmez)


### PR DESCRIPTION
## Summary
- Remove redundant `getfield_default` helper, leaving a single implementation.
- Previously removed duplicate `local_JPattern` definition for consistent interface.

## Testing
- `apt-get install -y octave` *(fails: ca-certificates-java post-installation script error)*
- `octave --quiet damper.m` *(fails: 'ensure_cfg_defaults' undefined)*
- `matlab -batch "damper"` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0badc3248328a4431b14ca368675